### PR TITLE
fixed DataD constructor for GHC 8.2

### DIFF
--- a/src/Syntax/IMPEG.hs
+++ b/src/Syntax/IMPEG.hs
@@ -332,7 +332,7 @@ instance (Typeable1 p, Data (p (Located (Type tyid))), Data tyid, Data typaram) 
 
 -- Rather than manually defining these instances, we use Template Haskell to do it for us.
 
-#if __GLASGOW_HASKELL__ >= 821
+#ifdef MIN_VERSION_GLASGOW_HASKELL && MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
 
 $(let types = [''Scheme, ''Decls, ''Primitive, ''Signature, ''TypingGroup, ''Pattern, ''Match, ''Guard, ''Expr]
       mkClause k z (RecC name args) = mkClause k z (NormalC name (map undefined args))

--- a/src/Syntax/IMPEG.hs
+++ b/src/Syntax/IMPEG.hs
@@ -332,7 +332,7 @@ instance (Typeable1 p, Data (p (Located (Type tyid))), Data tyid, Data typaram) 
 
 -- Rather than manually defining these instances, we use Template Haskell to do it for us.
 
-#ifdef MIN_VERSION_GLASGOW_HASKELL && MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+#if defined(MIN_VERSION_GLASGOW_HASKELL) && MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
 
 $(let types = [''Scheme, ''Decls, ''Primitive, ''Signature, ''TypingGroup, ''Pattern, ''Match, ''Guard, ''Expr]
       mkClause k z (RecC name args) = mkClause k z (NormalC name (map undefined args))

--- a/src/Syntax/IMPEG.hs
+++ b/src/Syntax/IMPEG.hs
@@ -1,4 +1,3 @@
-
 {-# LANGUAGE CPP, FlexibleContexts, FlexibleInstances, TypeSynonymInstances, UndecidableInstances, DeriveDataTypeable, StandaloneDeriving, TemplateHaskell, ScopedTypeVariables #-}
 module Syntax.IMPEG (module Syntax.Common, module Syntax.IMPEG) where
 

--- a/src/Syntax/IMPEG.hs
+++ b/src/Syntax/IMPEG.hs
@@ -1,10 +1,18 @@
-{-# LANGUAGE CPP, FlexibleContexts, FlexibleInstances, TypeSynonymInstances, UndecidableInstances, DeriveDataTypeable, StandaloneDeriving, TemplateHaskell, ScopedTypeVariables #-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE DeriveDataTypeable   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Syntax.IMPEG (module Syntax.Common, module Syntax.IMPEG) where
 
-import Language.Haskell.TH hiding (Match, Type, Guard, Kind)
-import Data.Generics hiding (Fixity)
-import Data.List
-import Syntax.Common
+import           Data.Generics       hiding (Fixity)
+import           Data.List
+import           Language.Haskell.TH hiding (Guard, Kind, Match, Type)
+import           Syntax.Common
 
 --------------------------------------------------------------------------------
 -- Kinds and types
@@ -151,11 +159,11 @@ data Pattern p tyid = PWild
                     | PGuarded (Pattern p tyid) (Guard p tyid)
 
 instance Binder (Pattern p t)
-    where bound PWild              = []
-          bound (PVar id)          = [id]
-          bound (PCon _ ids)       = ids
-          bound (PTyped p _)       = bound p
-          bound (PGuarded p g)     = bound p ++ bound g
+    where bound PWild          = []
+          bound (PVar id)      = [id]
+          bound (PCon _ ids)   = ids
+          bound (PTyped p _)   = bound p
+          bound (PGuarded p g) = bound p ++ bound g
 
 instance HasVariables (Pattern p t)
     where freeVariables PWild          = []
@@ -259,8 +267,8 @@ type Primitives p tyid = [Located (Primitive p tyid)]
 -- Programs
 --------------------------------------------------------------------------------
 
-data Program p tyid typaram = Program { decls    :: Decls p tyid
-                                      , topDecls :: TopDecls p tyid typaram
+data Program p tyid typaram = Program { decls      :: Decls p tyid
+                                      , topDecls   :: TopDecls p tyid typaram
                                       , primitives :: Primitives p tyid }
 
 emptyProgram = Program { decls      = emptyDecls
@@ -339,6 +347,6 @@ $(let types = [''Scheme, ''Decls, ''Primitive, ''Signature, ''TypingGroup, ''Pat
       mkInstance x = do
                TyConI dec <- reify x
                case dec of
-                 DataD [] name typarams cons _ ->
+                 DataD [] name typarams _ cons _  ->
                    [d|instance (Typeable1 p, Data (p (Located (Type tyid))), Data tyid) => Data ($(conT name) p tyid) where gfoldl k z x = $(caseE (varE 'x) (map (mkClause 'k 'z) cons)) |]
   in (return . concat) =<< mapM mkInstance types)


### PR DESCRIPTION
I believe a constructor argument was missed for DataD in src/Syntax/IMPEG.hs causing`make alb` to fail. small push to fix it.

```
$ make alb
ghc  --make -XOverloadedStrings -O2 -j3 -o alb -odir obj -hidir obj -isrc src/Driver.hs -rtsopts

src/Common.hs:1:102: warning:
    -XOverlappingInstances is deprecated: instead use per-instance pragmas OVERLAPPING/OVERLAPPABLE/OVERLAPS
  |
1 | {-# LANGUAGE FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, OverlappingInstances, TemplateHaskell #-}
  |                                                                                                      ^^^^^^^^^^^^^^^^^^^^

src/Solver/Syntax.hs:1:33: warning:
    -XOverlappingInstances is deprecated: instead use per-instance pragmas OVERLAPPING/OVERLAPPABLE/OVERLAPS
  |
1 | {-# LANGUAGE FlexibleInstances, OverlappingInstances #-}
  |                                 ^^^^^^^^^^^^^^^^^^^^

src/Solver/PP.hs:1:73: warning:
    -XOverlappingInstances is deprecated: instead use per-instance pragmas OVERLAPPING/OVERLAPPABLE/OVERLAPS
  |
1 | {-# LANGUAGE FlexibleContexts, FlexibleInstances, TypeSynonymInstances, OverlappingInstances, OverloadedStrings #-}
  |                                                                         ^^^^^^^^^^^^^^^^^^^^

src/Fidget/SpecialTypes.hs:1:73: warning:
    -XOverlappingInstances is deprecated: instead use per-instance pragmas OVERLAPPING/OVERLAPPABLE/OVERLAPS
  |
1 | {-# LANGUAGE FlexibleContexts, FlexibleInstances, TypeSynonymInstances, OverlappingInstances, TupleSections, PatternGuards, Rank2Types #-}
  |                                                                         ^^^^^^^^^^^^^^^^^^^^
[27 of 76] Compiling Syntax.IMPEG     ( src/Syntax/IMPEG.hs, obj/Syntax/IMPEG.o )

src/Syntax/IMPEG.hs:342:18: error:
    • The constructor ‘DataD’ should have 6 arguments, but has been given 5
    • In the pattern: DataD [] name typarams cons _
      In a case alternative:
          DataD [] name typarams cons _
            -> [d| instance (Typeable1 p,
                             Data (p (Located (Type tyid))),
                             Data tyid) =>
                            Data ($(conT name) p tyid) where
                     gfoldl k z x = $(caseE (varE ...) (map (mkClause ... ...) cons)) |]
               pending(rn) [<splice, caseE (varE 'x) (map (mkClause 'k 'z) cons)>,
                            <splice, conT name>]
      In a stmt of a 'do' block:
        case dec of {
          DataD [] name typarams cons _
            -> [d| instance (Typeable1 p,
                             Data (p (Located (Type tyid))),
                             Data tyid) =>
                            Data ($(conT name) p tyid) where
                     gfoldl k z x = ... |]
               pending(rn) [<splice, caseE (varE 'x) (map (mkClause 'k 'z) cons)>,
                            <splice, conT name>] }
    |
342 |                  DataD [] name typarams cons _ ->
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
make: *** [alb] Error 1

```