### PR TITLE
Fix latest ghc version complie errors

### DIFF
--- a/src/Solver/Tactics.hs
+++ b/src/Solver/Tactics.hs
@@ -3,6 +3,7 @@ module Solver.Tactics where
 
 import qualified Control.Applicative
 import Control.Monad (MonadPlus(..), foldM, liftM2, msum, replicateM, when)
+import qualified Control.Monad.Fail as Fail
 import qualified Data.IntSet as Set
 import Data.List
 import Data.Maybe
@@ -720,7 +721,8 @@ instance Monad Tactic
 -- strings to provide diagnostic information on why tactics are being skipped, but at the moment I
 -- don't think it would serve any purpose.
 
-          fail _   = Tactic (\st -> (NoProgress, st))
+instance Fail.MonadFail Tactic
+    where fail _   = Tactic (\st -> (NoProgress, st))
 
 -- return, noProgress, and exit correspond to the three constructors of the TacticResult type.
 

--- a/src/Typechecker/TypeInference/Base.hs
+++ b/src/Typechecker/TypeInference/Base.hs
@@ -6,6 +6,7 @@ import Prelude hiding ((<$>))
 import Common
 import Control.Monad
 import Control.Monad.State
+import qualified Control.Monad.Fail as Fail
 import Data.List (intercalate, nub, partition)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -177,6 +178,9 @@ predAtConstraints (At _ (Pred _ ts _)) = concatMap atConstraints ts
 
 newtype M t = M { runM :: StateT TcState Base t }
     deriving (Functor, Applicative, Monad, MonadBase, MonadState TcState)
+
+instance Fail.MonadFail M
+    where fail = error
 
 newTyVar :: Kind -> M Ty
 newTyVar k = do v <- fresh "t"


### PR DESCRIPTION
Add MonadFail instances for Tactic and M as fail is removed from Control.Monad. This proposal for MonadFail is fully detailed at [https://prime.haskell.org/wiki/Libraries/Proposals/MonadFail](https://prime.haskell.org/wiki/Libraries/Proposals/MonadFail)

This makes Alb compilable on GHC version 8.6.3

Tested and successfully builds on versions 8.0.2 and 8.6.3