### PR TITLE
Use system `milc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,23 @@ RUNNING
 Albatross is a batch compiler, and currently lacks an interactive mode.
 Flags can be listed using command line option `--help`.
 
-Without overriding flags, Alb will attempt to generate LC and invoke the MIL tools to produce an
-executable.
+Without overriding flags, Alb will attempt to generate LC and invoke the [MIL
+tools](https://github.com/habit-lang/mil-tools) to produce an executable. The
+`milc` script provided by MIL tools must be in your path. 
 
 Unless the `--no-dot-files` option is specified, Alb will look for files called ".alb" in your home
 directory and the current directory, and will read options from those files.  Options on the command
 line override options in files, and options in the local directory override options in your home
 directory.
+
+It is possible to customize the location of the `milc` script using the `--milc`
+command line option. The optional `--milc-opt` flag specifies additional command
+line options to pass to `milc`.
+
+#### Convering old `.alb` files
+
+Older `.alb` files *must* remove the `--mil-jar` option. If you need to specify
+a custom location for MIL tools, use the `--milc` and `--milc-opt` options.
 
 HABIT LANGUAGE EXTENSIONS
 -------------------------

--- a/src/Driver.hs
+++ b/src/Driver.hs
@@ -204,20 +204,26 @@ options =
     , Option [] ["no-dot-files"] (NoArg (\opt -> opt { dotFiles = False } ))
         "Does not include preferences from any previously checked dot files"
 
-    , Option [] ["mil-jar"] (ReqArg (\x opt -> opt { milOptions = (milOptions opt) { MILTools.jarPath = Just x } }) "PATH")
-         "Path to the MIL-tools JAR file"
+    -- , Option [] ["mil-jar"] (ReqArg (\x opt -> opt { milOptions = (milOptions opt) { MILTools.jarPath = Just x } }) "PATH")
+    --      "Path to the MIL-tools JAR file"
 
-    , Option [] ["llvm-main"] (ReqArg (\x opt -> opt{ milOptions = (milOptions opt){ MILTools.llvmMain = Just x }}) "STRING")
-           "Name of the main/initialization function to be generated in LLVM"
-
-    , Option [] ["mil-opt"] (ReqArg (\x opt -> opt { milOptions = (milOptions opt) { MILTools.otherOptions = x ++ otherOptions (milOptions opt) }}) "STRING")
-          "Other options to MIL-tools"
+    , Option [] ["milc"] (ReqArg (\x opt -> opt { milOptions = (milOptions opt) { MILTools.milcPath = Just x} }) "FILE")
+         "Path to the milc script"
 
     , Option [] ["include-mil"] (ReqArg (\x opt -> opt{ milOptions = (milOptions opt){ extraMilFiles = extraMilFiles (milOptions opt) ++ [x] } }) "FILE")
           "Additional MIL files to pass to MIL-tools"
 
+    , Option [] ["llvm-main"] (ReqArg (\x opt -> opt{ milOptions = (milOptions opt){ MILTools.llvmMain = Just x }}) "STRING")
+           "Name of the main/initialization function to be generated in LLVM"
+
+    -- , Option [] ["mil-opt"] (ReqArg (\x opt -> opt { milOptions = (milOptions opt) { MILTools.otherOptions = x ++ otherOptions (milOptions opt) }}) "STRING")
+    --       "Other options to MIL-tools"
+
+    , Option [] ["milc-opt"] (ReqArg (\x opt -> opt{ milOptions = (milOptions opt) {MILTools.otherOptions = x ++ otherOptions (milOptions opt)} }) "STRING")
+         "Other options to milc"
+
     , Option [] ["fake-mil"] (NoArg (\opt -> opt { milOptions = (milOptions opt) { MILTools.fake = True } }))
-          "Generate LC output and MIL-tools command, but do not actually invoke MIL-tools"
+          "Generate LC output and milc command, but do not actually invoke milc"
 
     , Option [] ["clang"] (ReqArg (\x opt -> opt{ milOptions = (milOptions opt){ clangPath = Just x } }) "FILE")
           "Path to clang binary (or replacement script)"

--- a/src/Driver.hs
+++ b/src/Driver.hs
@@ -204,9 +204,6 @@ options =
     , Option [] ["no-dot-files"] (NoArg (\opt -> opt { dotFiles = False } ))
         "Does not include preferences from any previously checked dot files"
 
-    -- , Option [] ["mil-jar"] (ReqArg (\x opt -> opt { milOptions = (milOptions opt) { MILTools.jarPath = Just x } }) "PATH")
-    --      "Path to the MIL-tools JAR file"
-
     , Option [] ["milc"] (ReqArg (\x opt -> opt { milOptions = (milOptions opt) { MILTools.milcPath = Just x} }) "FILE")
          "Path to the milc script"
 
@@ -215,9 +212,6 @@ options =
 
     , Option [] ["llvm-main"] (ReqArg (\x opt -> opt{ milOptions = (milOptions opt){ MILTools.llvmMain = Just x }}) "STRING")
            "Name of the main/initialization function to be generated in LLVM"
-
-    -- , Option [] ["mil-opt"] (ReqArg (\x opt -> opt { milOptions = (milOptions opt) { MILTools.otherOptions = x ++ otherOptions (milOptions opt) }}) "STRING")
-    --       "Other options to MIL-tools"
 
     , Option [] ["milc-opt"] (ReqArg (\x opt -> opt{ milOptions = (milOptions opt) {MILTools.otherOptions = x ++ otherOptions (milOptions opt)} }) "STRING")
          "Other options to milc"


### PR DESCRIPTION
Rather than require `alb` to know the path to the MIL tools JAR files, this patch moves `alb` to using a `milc` script found in the user's `PATH`.

Historically, `alb` relied on the user providing a path to MIL tools JAR files. This is problematic for users wanting to use the same options to all invocations of MIL tools.

This PR modifies `alb` so it looks for a `milc` script somewhere in the user's `PATH`. This provides greater flexibility through:
- `--milc` for a custom MIL-tools script location.
- `--milc-opt` to supply additional options to `milc`.
- `--include-mil` to provide additional includes for MIL tools.

Finally, this PR updates the README to include instructions to migrate from the current `.alb` file configuration to the new `.alb` file for the common case (providing a `--mil-jar` in the local `.alb` file). In the common case, you'll only need to delete the `--mil-jar` line from your .alb file.


