### PR TITLE
Workaround cabal run not defaulting to exe component

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -97,7 +97,8 @@ MILC=milc
 
 CLANG_EXE=/usr/bin/clang
 
-ALB_EXE=cabal run alb
+# Workaround for cabal run not defaulting to exe component (see: https://github.com/haskell/cabal/issues/7403)
+ALB_EXE=cabal run alb:exe:alb
 
 MIL_OPTS=--milc=$(MIL_DIR)/$(MILC) --include-mil $(MIL_DIR)/lib/basic.mil --llvm-main main
 


### PR DESCRIPTION
Workaround taken from: https://github.com/haskell/cabal/issues/7403, according to said issue it seems like work is being done to fix it for good so we can revert this whenever that happens.

With this change, tests will atleast run, but will still halt with the issue(s) described in #19 